### PR TITLE
Adjust group priorities to reorganize menu layout

### DIFF
--- a/src/game/frontend/submenus/Recovery/Heist/KortzCenterHeist.cpp
+++ b/src/game/frontend/submenus/Recovery/Heist/KortzCenterHeist.cpp
@@ -7,11 +7,10 @@ namespace YimMenu::Submenus
 		auto tab = std::make_shared<TabItem>("Kortz Center Heist");
 
 		auto target    = std::make_shared<Group>("Primary Target", 1);
-		auto general   = std::make_shared<Group>("General", 2);
-		auto preps     = std::make_shared<Group>("Prep Work", 2);
-		auto scoping   = std::make_shared<Group>("Scoping", 2);
-		auto action    = std::make_shared<Group>("", 1);
-		auto misc = std::make_shared<Group>("Misc", 1);
+		auto general   = std::make_shared<Group>("General", 1);
+		auto preps     = std::make_shared<Group>("Prep Work", 4);
+		auto scoping   = std::make_shared<Group>("Scoping & Setup", 1);
+		auto misc = std::make_shared<Group>("Misc", 4);
 
 
 		target->AddItem(std::make_shared<ListCommandItem>("kortzcenterheistprimarytarget"_J));
@@ -41,17 +40,17 @@ namespace YimMenu::Submenus
 		scoping->AddItem(std::make_shared<BoolCommandItem>("kortzcenterheistscopesecondary"_J));
 		scoping->AddItem(std::make_shared<BoolCommandItem>("kortzcenterheistscopepoi"_J));
 
-		action->AddItem(std::make_shared<CommandItem>("kortzcenterheistsetup"_J, "Setup##kortz"));
+		scoping->AddItem(std::make_shared<CommandItem>("kortzcenterheistsetup"_J, "Setup##kortz"));
 
 
 		misc->AddItem(std::make_shared<CommandItem>("kortz_skip_fingerprint_hack"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_skip_Signal_Nodes_hack"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_take_primary"_J));
+		misc->AddItem(std::make_shared<CommandItem>("kortz_centercooldowns"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_take_secondary"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_disablelasergrid"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_skipdatacrack"_J));
 		misc->AddItem(std::make_shared<CommandItem>("kortz_cutglass"_J));
-		misc->AddItem(std::make_shared<CommandItem>("kortz_centercooldowns"_J));
 		misc->AddItem(std::make_shared<BoolCommandItem>("kortz_centerpayouts"_J));
 
 
@@ -60,7 +59,6 @@ namespace YimMenu::Submenus
 		tab->AddItem(general);
 		tab->AddItem(preps);
 		tab->AddItem(scoping);
-		tab->AddItem(action);
 		tab->AddItem(misc);
 
 		return tab;


### PR DESCRIPTION
Reorganizes its group layout for better readability. UI-only change, no command IDs, JOAAT hashes, or gameplay logic are affected.

Groups (KortzCenterHeist.cpp):
- General: columns 2 -> 1
- Prep Work: columns 2 -> 4
- Scoping: renamed to "Scoping & Setup", columns 2 -> 1
- Misc: columns 1 -> 4
- Removed empty `action` group (std::make_shared<Group>("", 1))

Item moves:
- kortzcenterheistsetup (Setup button) moved from removed `action` group into `Scoping & Setup`. Command and label unchanged; behavior identical.
- Misc reordered so kortz_centercooldowns sits after kortz_take_primary: Row 1: skip_fingerprint_hack, skip_Signal_Nodes_hack, take_primary, centercooldowns Row 2: take_secondary, disablelasergrid, skipdatacrack, cutglass kortz_centerpayouts (bool toggle) remains last on the right.

Tab registration:
- Removed `tab->AddItem(action);` since the group no longer exists.